### PR TITLE
benchmark various readString implementations

### DIFF
--- a/protocol/binary/stream_reader_test.go
+++ b/protocol/binary/stream_reader_test.go
@@ -43,8 +43,25 @@ func BenchmarkReadString(b *testing.B) {
 	defer sr.Close()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		sr.ReadString()
-		enc.Seek(0, io.SeekStart)
-	}
+
+	b.Run("original", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			sr.readStringOrig()
+			enc.Seek(0, io.SeekStart)
+		}
+	})
+
+	b.Run("unsafe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			sr.readStringUnsafe()
+			enc.Seek(0, io.SeekStart)
+		}
+	})
+
+	b.Run("builder_copyN", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			sr.readStringBuilderCopyN()
+			enc.Seek(0, io.SeekStart)
+		}
+	})
 }

--- a/protocol/binary/string_post_go120.go
+++ b/protocol/binary/string_post_go120.go
@@ -23,7 +23,11 @@
 
 package binary
 
-import "unsafe"
+import (
+	"io"
+	"strings"
+	"unsafe"
+)
 
 // ReadString reads a Thrift encoded string.
 func (sr *StreamReader) ReadString() (string, error) {
@@ -41,4 +45,39 @@ func (sw *StreamWriter) WriteString(s string) error {
 
 	b := unsafe.Slice(unsafe.StringData(s), len(s))
 	return sw.write(b)
+}
+
+func (sr *StreamReader) readStringUnsafe() (string, error) {
+	bs, err := sr.ReadBinary()
+	// It is safe to use "unsafe" here because there are no
+	// mutable references to bs.
+	return unsafe.String(unsafe.SliceData(bs), len(bs)), err
+}
+
+func (sr *StreamReader) readStringOrig() (string, error) {
+	bs, err := sr.ReadBinary()
+	return string(bs), err
+}
+
+func (sr *StreamReader) readStringBuilderCopyN() (string, error) {
+	length, err := sr.ReadInt32()
+	if err != nil {
+		return "", err
+	}
+
+	if length < 0 {
+		return "", decodeErrorf("negative length %v specified for binary field", length)
+	}
+
+	if length == 0 {
+		return "", nil
+	}
+
+	var b strings.Builder
+	_, err = io.CopyN(&b, sr.reader, int64(length))
+	if err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
 }


### PR DESCRIPTION
goos: linux
goarch: amd64
pkg: go.uber.org/thriftrw/protocol/binary
cpu: AMD EPYC 7B13
BenchmarkReadString/original            14834030                85.39 ns/op           96 B/op          2 allocs/op
BenchmarkReadString/original            14919061                81.05 ns/op           96 B/op          2 allocs/op
BenchmarkReadString/original            14819980                85.72 ns/op           96 B/op          2 allocs/op
BenchmarkReadString/unsafe              22125171                55.34 ns/op           48 B/op          1 allocs/op
BenchmarkReadString/unsafe              22407374                54.63 ns/op           48 B/op          1 allocs/op
BenchmarkReadString/unsafe              22261762                56.61 ns/op           48 B/op          1 allocs/op
BenchmarkReadString/builder_copyN        6270338               194.0 ns/op           152 B/op          4 allocs/op
BenchmarkReadString/builder_copyN        5996749               194.3 ns/op           152 B/op          4 allocs/op
BenchmarkReadString/builder_copyN        6101299               195.3 ns/op           152 B/op          4 allocs/op